### PR TITLE
Fix height measurement

### DIFF
--- a/library/src/com/manuelpeinado/quickreturnheader/QuickReturnHeaderHelper.java
+++ b/library/src/com/manuelpeinado/quickreturnheader/QuickReturnHeaderHelper.java
@@ -88,7 +88,9 @@ public class QuickReturnHeaderHelper implements OnGlobalLayoutListener {
         // Use measured height here as an estimate of the header height, later on after the layout is complete 
         // we'll use the actual height
         int widthMeasureSpec = MeasureSpec.makeMeasureSpec(LayoutParams.MATCH_PARENT, MeasureSpec.EXACTLY);
-        int heightMeasureSpec = MeasureSpec.makeMeasureSpec(LayoutParams.WRAP_CONTENT, MeasureSpec.EXACTLY);
+        //int heightMeasureSpec = MeasureSpec.makeMeasureSpec(LayoutParams.WRAP_CONTENT, MeasureSpec.EXACTLY);
+        int heightMeasureSpec = (int) context.getResources().getDimension(R.dimen.abs__action_bar_default_height);
+        
         realHeader.measure(widthMeasureSpec, heightMeasureSpec);
         headerHeight = realHeader.getMeasuredHeight();
 


### PR DESCRIPTION
In Android 4.3 and later, the line 91 doesn't return any real data, so I changed to get the actual height from the dimen resource.
